### PR TITLE
fix echo in zip installer script

### DIFF
--- a/install_zip/make_updater_script.sh
+++ b/install_zip/make_updater_script.sh
@@ -34,6 +34,6 @@ done
 
 assert_str="${assert_str% || \\n *});\n"
 
-echo -e "$assert_str" > ${SCRIPT_PATH}/updater-script || fail "Failed to write assert line into updater-script!"
+echo "$assert_str" > ${SCRIPT_PATH}/updater-script || fail "Failed to write assert line into updater-script!"
 cat ${SCRIPT_PATH}/updater-script-base >> ${SCRIPT_PATH}/updater-script || fail "Failed to add base updater-script file!"
 rm ${SCRIPT_PATH}/updater-script-base


### PR DESCRIPTION
"echo -e" behaves differently across shells, in my case it broke the installer script
see https://mail.gnome.org/archives/commits-list/2011-July/msg04152.html
