### PR TITLE
Explicitly create /mnt when doing loop mounts for Linux ROMs

### DIFF
--- a/multirom.c
+++ b/multirom.c
@@ -1717,6 +1717,7 @@ int multirom_fill_kexec_linux(struct multirom_status *s, struct multirom_rom *ro
             char *img_fs = map_get_val(info->str_vals, "root_img_fs");
 
             // mount the image file
+            mkdir("/mnt", 0777);
             mkdir("/mnt/image", 0777);
             if(multirom_mount_loop(path, "/mnt/image", img_fs ? img_fs : "ext4", MS_NOATIME, NULL) < 0)
                 goto exit;


### PR DESCRIPTION
I found that, on the Glitch CAF kernel for flo, /mnt doesn't exist in the ramdisk. It causes any attempt to boot a Linux ROM (using the text file template from the wiki and an image instead of a subdirectory) to fail.

This creates it explicitly before it's needed. If it's already there, the mkdir call will fail, but there will be no adverse effects.
