### PR TITLE
Fix dtb variable name

### DIFF
--- a/install_zip/prebuilt-uninstaller/scripts/clear_boot.sh
+++ b/install_zip/prebuilt-uninstaller/scripts/clear_boot.sh
@@ -89,7 +89,7 @@ if [ -f "dtb.img" ]; then
     dtb_cmd="-d dtb.img"
 fi
 
-/tmp/bbootimg --create newboot.img -f bootimg.cfg -k zImage -r initrd.img $dtb
+/tmp/bbootimg --create newboot.img -f bootimg.cfg -k zImage -r initrd.img $dtb_cmd
 
 if [ ! -e "/tmp/newboot.img" ] ; then
     echo "Failed to inject boot.img!"


### PR DESCRIPTION
Using $dtb which isn't defined creates a boot.img without dtb image which fails to boot
