### PR TITLE
Set SELinux to permissive on secondary ROMs boot

### DIFF
--- a/multirom.c
+++ b/multirom.c
@@ -1731,8 +1731,9 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
         goto exit;
     }
 
-    if(sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("androidboot.selinux=permissive"))
-        strcat(cmdline, "androidboot.selinux=permissive ");
+    if(!strstr(cmdline, "androidboot.selinux=permissive"))
+        if(sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("androidboot.selinux=permissive"))
+            strcat(cmdline, "androidboot.selinux=permissive ");
 
     if(sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("mrom_kexecd=1"))
         strcat(cmdline, "mrom_kexecd=1");

--- a/multirom.c
+++ b/multirom.c
@@ -1731,6 +1731,9 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
         goto exit;
     }
 
+    if(sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("androidboot.selinux=permissive"))
+        strcat(cmdline, "androidboot.selinux=permissive ");
+
     if(sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("mrom_kexecd=1"))
         strcat(cmdline, "mrom_kexecd=1");
 


### PR DESCRIPTION
Booting secondary ROMs fails on enforcing SELinux so set it to permissive