### PR TITLE
Initialize adb via usb_function_switch

### DIFF
--- a/trampoline/adb.c
+++ b/trampoline/adb.c
@@ -148,6 +148,7 @@ void adb_init_usb(void)
     write_file("/sys/class/android_usb/android0/iSerial", serial);
 
     write_file("/sys/class/android_usb/android0/enable", "1");
+    write_file("/sys/devices/platform/android_usb/usb_function_switch", "3");
 }
 
 int adb_init_busybox(void)


### PR DESCRIPTION
Fixes adb functionality on M8 (and possibly other future/newer HTC devices)