### PR TITLE
Set correct context for .layout_version

### DIFF
--- a/multirom.c
+++ b/multirom.c
@@ -1397,11 +1397,11 @@ int multirom_create_media_link(void)
             fputc(api_level > 19 ? '3' : '2', f);
             fclose(f);
             chmod(LAYOUT_VERSION, 0600);
-
-            if(api_level >= 21)
-                if(mr_system("chcon -t install_data_file %s", LAYOUT_VERSION) != 0)
-                    ERROR("Failed to set SELinux context to .layout_version\n");
         }
+
+        if(api_level >= 21)
+            if(mr_system("chcon -t install_data_file %s", LAYOUT_VERSION) != 0)
+                ERROR("Failed to set SELinux context to .layout_version\n");
     }
 
     return 0;

--- a/multirom.c
+++ b/multirom.c
@@ -1397,6 +1397,10 @@ int multirom_create_media_link(void)
             fputc(api_level > 19 ? '3' : '2', f);
             fclose(f);
             chmod(LAYOUT_VERSION, 0600);
+
+            if(api_level >= 21)
+                if(mr_system("chcon -t install_data_file %s", LAYOUT_VERSION) != 0)
+                    ERROR("Failed to set SELinux context to .layout_version\n");
         }
     }
 


### PR DESCRIPTION
If .layout_version remains unlabeled the phone won't be able to access the sdcard
Thanks to @nkk71 for finding the issue