### PR TITLE
Support for arm64 kexec-tools, add hook for starting decryption daemon on Snapdragon 810, fix decryption on N preview

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/multirom-nexus6p/multirom_adbd.git
 [submodule "kexec-tools-arm64"]
 	path = kexec-tools-arm64
-	url = https://github.com/multirom-nexus6p/kexec-tools.git
+	url = https://github.com/npjohnson/kexec-tools-arm64.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/multirom-nexus6p/multirom_adbd.git
 [submodule "kexec-tools-arm64"]
 	path = kexec-tools-arm64
-	url = https://github.com/npjohnson/kexec-tools-arm64.git
+	url = https://github.com/multirom-nexus6p/kexec-tools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Tasssadar/kexec-tools
 [submodule "adbd"]
 	path = adbd
-	url = https://github.com/Tasssadar/multirom_adbd.git
+	url = https://github.com/multirom-nexus6p/multirom_adbd.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "adbd"]
 	path = adbd
 	url = https://github.com/multirom-nexus6p/multirom_adbd.git
+[submodule "kexec-tools-arm64"]
+	path = kexec-tools-arm64
+	url = https://github.com/multirom-nexus6p/kexec-tools.git

--- a/Android.mk
+++ b/Android.mk
@@ -72,6 +72,11 @@ else
     include $(multirom_local_path)/kexec-tools/Android.mk
 endif
 
+# Make code aware of the Arch
+ifneq ($(TARGET_ARCH),arm64)
+    LOCAL_CFLAGS += -DMR_NOT_64BIT
+endif
+
 # adbd
 include $(multirom_local_path)/adbd/Android.mk
 

--- a/Android.mk
+++ b/Android.mk
@@ -66,7 +66,11 @@ include $(multirom_local_path)/trampoline/Android.mk
 include $(multirom_local_path)/install_zip/Android.mk
 
 # Kexec-tools
-include $(multirom_local_path)/kexec-tools/Android.mk
+ifeq ($(TARGET_ARCH),arm64)
+    include $(multirom_local_path)/kexec-tools-arm64/Android.mk
+else
+    include $(multirom_local_path)/kexec-tools/Android.mk
+endif
 
 # adbd
 include $(multirom_local_path)/adbd/Android.mk

--- a/hooks.h
+++ b/hooks.h
@@ -44,6 +44,7 @@ int mrom_hook_has_kexec(void);
 #if MR_DEVICE_HOOKS >= 6
 void tramp_hook_encryption_setup(void);
 void tramp_hook_encryption_cleanup(void);
+void mrom_hook_fixup_full_cmdline(char *bootimg_cmdline, size_t bootimg_cmdline_cap);
 #endif
 
 #endif /* MR_DEVICE_HOOKS */

--- a/hooks.h
+++ b/hooks.h
@@ -41,6 +41,11 @@ void mrom_hook_fixup_bootimg_cmdline(char *bootimg_cmdline, size_t bootimg_cmdli
 int mrom_hook_has_kexec(void);
 #endif
 
+#if MR_DEVICE_HOOKS >= 6
+void tramp_hook_encryption_setup(void);
+void tramp_hook_encryption_cleanup(void);
+#endif
+
 #endif /* MR_DEVICE_HOOKS */
 
 #endif /* MR_DEVICE_HOOKS_H */

--- a/install_zip/Android.mk
+++ b/install_zip/Android.mk
@@ -14,7 +14,7 @@ endif
 
 multirom_extra_dep :=
 ifeq ($(MR_ENCRYPTION),true)
-	multirom_extra_dep += trampoline_encmnt linker
+	multirom_extra_dep += trampoline_encmnt linker libmultirom_fake_properties
 else
 	MR_ENCRYPTION := false
 endif
@@ -59,6 +59,7 @@ $(MULTIROM_ZIP_TARGET): multirom trampoline signapk bbootimg mrom_kexec_static m
 		cp -a $(TARGET_OUT_SHARED_LIBRARIES)/libm.so $(MULTIROM_INST_DIR)/multirom/enc/; \
 		cp -a $(TARGET_OUT_SHARED_LIBRARIES)/libstdc++.so $(MULTIROM_INST_DIR)/multirom/enc/; \
 		cp -a $(TARGET_OUT_SHARED_LIBRARIES)/libc++.so $(MULTIROM_INST_DIR)/multirom/enc/; \
+		cp -a $(TARGET_OUT_SHARED_LIBRARIES)/libmultirom_fake_properties.so $(MULTIROM_INST_DIR)/multirom/enc/; \
 		if [ -n "$(MR_ENCRYPTION_SETUP_SCRIPT)" ]; then sh "$(ANDROID_BUILD_TOP)/$(MR_ENCRYPTION_SETUP_SCRIPT)" "$(ANDROID_BUILD_TOP)" "$(MULTIROM_INST_DIR)/multirom/enc"; fi; \
 	fi
 

--- a/lib/containers.c
+++ b/lib/containers.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "containers.h"
 #include "util.h"

--- a/lib/framebuffer.h
+++ b/lib/framebuffer.h
@@ -21,6 +21,7 @@
 #include <linux/fb.h>
 #include <stdarg.h>
 #include <pthread.h>
+#include <string.h>
 
 #if defined(RECOVERY_BGRA) || defined(RECOVERY_RGBX)
 #define PIXEL_SIZE 4

--- a/lib/keyboard.c
+++ b/lib/keyboard.c
@@ -82,7 +82,7 @@ static const uint32_t normalKeycodeMapCharset3[] = {
 
 static const uint32_t normalKeycodeMapCharset4[] = {
     '~', '`', '|', '<', '>', '-', '+', '!', '?', ';',
-    OSK_EMPTY | KFLAG_HALF, '^', '\\', '$', '%', '&', '-', '+', '{', '}',
+    OSK_EMPTY | KFLAG_HALF, '^', '\\', '$', '%', '&', '-', '=', '{', '}',
     OSK_CHARSET3 | KFLAG_PLUS_HALF, '*', '"', '\'', ':', ';', '[', ']', OSK_BACKSPACE | KFLAG_PLUS_HALF, OSK_EMPTY,
     OSK_CHARSET1 | KS(2), ',', ' ' | KS(4), '/', OSK_ENTER | KS(2),
     0

--- a/lib/progressdots.c
+++ b/lib/progressdots.c
@@ -16,6 +16,7 @@
  */
 
 #include <unistd.h>
+#include <stdlib.h>
 
 #include "progressdots.h"
 #include "colors.h"

--- a/lib/util.c
+++ b/lib/util.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define _GNU_SOURCE
 
 #include <stdarg.h>
 #include <stdlib.h>
@@ -23,7 +24,6 @@
 #include <errno.h>
 #include <time.h>
 #include <dirent.h>
-#include <fcntl.h>
 #include <cutils/android_reboot.h>
 #include <unistd.h>
 

--- a/multirom.c
+++ b/multirom.c
@@ -1615,7 +1615,9 @@ int multirom_load_kexec(struct multirom_status *s, struct multirom_rom *rom)
     kexec_init(&kexec, kexec_path);
     kexec_add_arg(&kexec, "--mem-min="MR_KEXEC_MEM_MIN);
 #ifdef MR_KEXEC_DTB
+#ifdef MR_NOT_64BIT
     kexec_add_arg_prefix(&kexec, "--boardname=", TARGET_DEVICE);
+#endif
 #endif
 
     switch(rom->type)
@@ -1686,8 +1688,10 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
 #ifdef MR_KEXEC_DTB
     if(libbootimg_dump_dtb(&img, "/dtb.img") >= 0)
         kexec_add_arg(kexec, "--dtb=/dtb.img");
+#ifdef MR_NOT_64BIT
     else
         kexec_add_arg(kexec, "--dtb");
+#endif
 #endif
 
     char cmdline[1536];

--- a/multirom.c
+++ b/multirom.c
@@ -1686,12 +1686,16 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
     kexec_add_arg(kexec, "--initrd=/initrd.img");
 
 #ifdef MR_KEXEC_DTB
-    if(libbootimg_dump_dtb(&img, "/dtb.img") >= 0)
+    if(libbootimg_dump_dtb(&img, "/dtb.img") >= 0) {
+        printf("DTB: dtb image found!");
         kexec_add_arg(kexec, "--dtb=/dtb.img");
+    }
+    else {
+        printf("DTB: no dtb image found!");
 #ifdef MR_NOT_64BIT
-    else
         kexec_add_arg(kexec, "--dtb");
 #endif
+    }
 #endif
 
     char cmdline[1536];
@@ -1851,11 +1855,15 @@ int multirom_fill_kexec_linux(struct multirom_status *s, struct multirom_rom *ro
     }
     else
     {
+        printf("DTB: dtb image found!");
         str = find_boot_file("%r/dtb.img", root_path, rom->base_path);
     }
 
     if(!str)
+        printf("DTB: no dtb image found!");
+#ifdef MR_NOT_64BIT
         kexec_add_arg(kexec, "--dtb");
+#endif
     else
     {
         kexec_add_arg_prefix(kexec, "--dtb=", str);

--- a/multirom.c
+++ b/multirom.c
@@ -1715,6 +1715,10 @@ int multirom_fill_kexec_android(struct multirom_status *s, struct multirom_rom *
     if(!strstr(cmdline, " mrom_kexecd=1") && sizeof(cmdline)-strlen(cmdline)-1 >= sizeof("mrom_kexecd=1"))
         strcat(cmdline, "mrom_kexecd=1");
 
+#if MR_DEVICE_HOOKS >= 6
+    mrom_hook_fixup_full_cmdline(cmdline, sizeof(cmdline));
+#endif
+
     kexec_add_arg(kexec, cmdline);
 
     res = 0;

--- a/multirom.h
+++ b/multirom.h
@@ -20,6 +20,8 @@
 
 #include <pthread.h>
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 #include "lib/fstab.h"
 #include "lib/containers.h"

--- a/trampoline/Android.mk
+++ b/trampoline/Android.mk
@@ -40,4 +40,8 @@ ifeq ($(MR_ENCRYPTION),true)
     LOCAL_SRC_FILES += encryption.c
 endif
 
+ifeq ($(MR_ENCRYPTION_FAKE_PROPERTIES),true)
+    LOCAL_CFLAGS += -DMR_ENCRYPTION_FAKE_PROPERTIES
+endif
+
 include $(BUILD_EXECUTABLE)

--- a/trampoline/adb.c
+++ b/trampoline/adb.c
@@ -27,7 +27,9 @@
 #include <sys/mount.h>
 #include <sys/klog.h>
 #include <linux/loop.h>
+#include <unistd.h>
 
+#include <fcntl.h>
 #include "adb.h"
 #include "../lib/util.h"
 #include "../lib/log.h"

--- a/trampoline/encryption.c
+++ b/trampoline/encryption.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/trampoline_encmnt/Android.mk
+++ b/trampoline_encmnt/Android.mk
@@ -27,3 +27,14 @@ LOCAL_SRC_FILES := \
 include $(multirom_local_path)/device_defines.mk
 
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libmultirom_fake_properties
+LOCAL_MODULE_TAGS := eng
+LOCAL_C_INCLUDES += $(multirom_local_path)
+
+LOCAL_SRC_FILES := fake_properties.c
+
+include $(multirom_local_path)/device_defines.mk
+include $(BUILD_SHARED_LIBRARY)

--- a/trampoline_encmnt/encmnt.c
+++ b/trampoline_encmnt/encmnt.c
@@ -49,6 +49,7 @@ static int get_footer_from_opts(char *output, size_t output_size, const char *op
     static const char *names[] = {
         "encryptable=",
         "forceencrypt=",
+        "forcefdeorfbe=",
         NULL
     };
 

--- a/trampoline_encmnt/encmnt.c
+++ b/trampoline_encmnt/encmnt.c
@@ -15,6 +15,7 @@
  * along with MultiROM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/trampoline_encmnt/fake_properties.c
+++ b/trampoline_encmnt/fake_properties.c
@@ -1,0 +1,33 @@
+/*
+ * This file is part of MultiROM.
+ *
+ * MultiROM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiROM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiROM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/system_properties.h>
+
+/* MultiROM doesn't initialize the property service,
+ * but decryption on Nexus 6P waits for one property to become true
+ * so we hardcode it here
+ */
+
+int property_get(const char *key, char *value, const char *default_value)
+{
+    if (!strcmp(key, "sys.listeners.registered"))
+        default_value = "true";
+    if (default_value)
+        strncpy(value, default_value, PROP_VALUE_MAX);
+    return strlen(value);
+}

--- a/trampoline_encmnt/pw_ui.c
+++ b/trampoline_encmnt/pw_ui.c
@@ -15,6 +15,7 @@
  * along with MultiROM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdlib.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <stdio.h>


### PR DESCRIPTION
This pull request adds two new hooks called before encryption start and at encryption cleanup. My Nexus 6P port uses them to start qseecomd.

In addition, a shim for property_get is added to get decryption to not hang on Nexus 6P.

Finally, a new submodule, kexec-tools-arm64 is added, which works for kexec on arm64. Currently it's hardcoded for Snapdragon 810 but will be modified to use addresses from the BoardConfig.

This pull request depends on Hashbang173's patches to make Multirom build in an Omni-6.0 tree and also swaps out the ADBD implementation to one from Omni-6.0. I have not tested building in an older tree, so there's likely breakage.
