### PR TITLE
New: Option to enable multirom kmsg logging + history

### DIFF
--- a/multirom.h
+++ b/multirom.h
@@ -104,6 +104,7 @@ struct multirom_status
     int colors;
     int brightness;
     int enable_adb;
+    int enable_kmsg_logging;
     int hide_internal;
     char *int_display_name;
     int rotation;


### PR DESCRIPTION
Adds the following to multirom-klogs dir:
- 5 last_kmsg log history
- current klog upon entering multirom
- current klog upon exiting multirom
- current kexc log

needs to be enabled in multirom.ini settings:
- enable_kmsg_logging=1
  or
- if you want to do it in TWRP
  eg https://github.com/nkk71/android_bootable_recovery/commit/497ce002dea9e80a9377f0f2d78e962d457fa681
