### PR TITLE
Fix "Directory nonexistent" error

### DIFF
--- a/install_zip/rename_zip.sh
+++ b/install_zip/rename_zip.sh
@@ -25,4 +25,4 @@ ver_dev=${ver_dev%\"}
 out_name="${ZIP_PATH}-$(date +%Y%m%d)-v${ver_main}${ver_dev}-UNOFFICIAL-${DEVICE}.zip"
 echo "--- Creating $out_name"
 cp -a "$ZIP_PATH.zip" "$out_name" || exit 1
-cd "$(dirname ${out_name})" && md5sum "$(basename ${out_name})" > "${out_name}.md5sum"
+cd "$(dirname ${out_name})" && md5sum "$(basename ${out_name})" > "$(basename ${out_name}).md5sum"


### PR DESCRIPTION
I get the following error message, when I do `make multirom_zip`:

```
--- Creating out/target/product/FP2/multirom-20160422-v33-UNOFFICIAL-FP2.zip
system/extras/multirom/install_zip/rename_zip.sh: 28: system/extras/multirom/install_zip/rename_zip.sh: cannot create out/target/product/FP2/multirom-20160422-v33-UNOFFICIAL-FP2.zip.md5sum: Directory nonexistent
make: *** [out/target/product/FP2/multirom] Error 2

#### make failed to build some targets (01:05 (mm:ss)) ####
```

without this patch, with it everything works as expected.
