### PR TITLE
Ability to explicitely set if heap_id_mask or heap_mask should be used.

### DIFF
--- a/lib/Android.mk
+++ b/lib/Android.mk
@@ -51,6 +51,9 @@ endif
 ifeq ($(MR_QCOM_OVERLAY_USE_VSYNC),true)
     common_C_FLAGS += -DMR_QCOM_OVERLAY_USE_VSYNC
 endif
+ifneq ($(MR_QCOM_OVERLAY_HEAP_ID_MASK),)
+    common_C_FLAGS += -DMR_QCOM_OVERLAY_HEAP_ID_MASK=$(MR_QCOM_OVERLAY_HEAP_ID_MASK)
+endif
 endif
 
 

--- a/lib/framebuffer_qcom_overlay.c
+++ b/lib/framebuffer_qcom_overlay.c
@@ -295,11 +295,22 @@ static int alloc_ion_mem(struct fb_qcom_overlay_data *data, unsigned int size)
     ionAllocData.len = size;
     ionAllocData.align = sysconf(_SC_PAGESIZE);
 
-// are you kidding me -.-
-#if (PLATFORM_SDK_VERSION >= 21)
-    ionAllocData.heap_id_mask =
+// Ability to explicitely set if heap_id_mask or heap_mask should be used.
+#ifdef MR_QCOM_OVERLAY_HEAP_ID_MASK
+    #if MR_QCOM_OVERLAY_HEAP_ID_MASK == 1
+        ionAllocData.heap_id_mask =
+    #elif MR_QCOM_OVERLAY_HEAP_ID_MASK == 2
+        ionAllocData.heap_mask =
+    #else
+        #error Please set MR_QCOM_OVERLAY_HEAP_ID_MASK to either 1 or 2, see source for details.
+    #endif
 #else
-    ionAllocData.heap_mask =
+    // are you kidding me -.-
+    #if (PLATFORM_SDK_VERSION >= 21)
+        ionAllocData.heap_id_mask =
+    #else
+        ionAllocData.heap_mask =
+    #endif
 #endif
             ION_HEAP(ION_IOMMU_HEAP_ID) |
             ION_HEAP(21); // ION_SYSTEM_CONTIG_HEAP_ID


### PR DESCRIPTION
Apply with `MR_QCOM_OVERLAY_HEAP_ID_MASK := 1` or `2` in your `BoardConfig.mk`. If not set, it will fall back to the old method (`>= API 21`)

This would fix #101 

This is probably the worst C preprocessor cluster, but it seems to work. If you know how it would be better, please tell me :)
